### PR TITLE
Lower to version go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ad9311/hitomgr
 
-go 1.19
+go 1.18
 
 require (
 	github.com/alexedwards/scs/v2 v2.5.0


### PR DESCRIPTION
- Lower to version go1.18 to be compatible with heroku